### PR TITLE
Handle `preventDefault` in `onKeyPress`.

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,12 @@ class ClickableBox extends React.Component {
     // Run user supplied `onKeyPress` first if there is one
     if (typeof onKeyPress === "function") {
       onKeyPress(event);
+
+      // Prevent `onClick` from running in the rare case that the user has a custom `onKeyPress`
+      // that contains `event.preventDefault()`.
+      if (event.isDefaultPrevented()) {
+        return;
+      }
     }
 
     switch (event.key) {

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -157,6 +157,29 @@ describe("events", () => {
     expect(onKeyPress).toHaveBeenCalledTimes(1);
   });
 
+  test("does not run `onClick` if a valid key is pressed, the consumer passes in their on `onKeyPress`, and the consumer's `onKeyPress` prevents the event", () => {
+    const handleClick = jest.fn();
+    const onKeyPressMock = jest.fn();
+
+    const onKeyPress = event => {
+      onKeyPressMock();
+
+      // This should prevent `onClick` from running.
+      event.preventDefault();
+    };
+
+    const { getByText } = render(
+      <ClickableBox onClick={handleClick} onKeyPress={onKeyPress}>
+        Submit
+      </ClickableBox>
+    );
+
+    fireEvent.keyPress(getByText("Submit"), validEnterPress);
+
+    expect(handleClick).toHaveBeenCalledTimes(0);
+    expect(onKeyPressMock).toHaveBeenCalledTimes(1);
+  });
+
   test("fires events on `keypress`, not `keydown`", () => {
     // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#Required_JavaScript_Features
     const handleClick = jest.fn();

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -159,14 +159,9 @@ describe("events", () => {
 
   test("does not run `onClick` if a valid key is pressed, the consumer passes in their on `onKeyPress`, and the consumer's `onKeyPress` prevents the event", () => {
     const handleClick = jest.fn();
-    const onKeyPressMock = jest.fn();
-
-    const onKeyPress = event => {
-      onKeyPressMock();
-
-      // This should prevent `onClick` from running.
+    const onKeyPress = jest.fn().mockImplementation(event => {
       event.preventDefault();
-    };
+    });
 
     const { getByText } = render(
       <ClickableBox onClick={handleClick} onKeyPress={onKeyPress}>
@@ -177,7 +172,7 @@ describe("events", () => {
     fireEvent.keyPress(getByText("Submit"), validEnterPress);
 
     expect(handleClick).toHaveBeenCalledTimes(0);
-    expect(onKeyPressMock).toHaveBeenCalledTimes(1);
+    expect(onKeyPress).toHaveBeenCalledTimes(1);
   });
 
   test("fires events on `keypress`, not `keydown`", () => {


### PR DESCRIPTION
This prevents the `onClick` from running if user's `onKeyPress` includes an `event.preventDefault()`.