### PR TITLE
Add `aria-disabled` when `disabled`.

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -56,6 +56,7 @@ class ClickableBox extends React.Component {
         role={isActiveButton ? "button" : undefined}
         onKeyPress={isActiveButton ? this.onKeyPress : undefined}
         onClick={isActiveButton ? onClick : undefined}
+        aria-disabled={!isActiveButton}
         ref={innerRef}
         {...otherProps}
       />

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -235,6 +235,16 @@ describe("disabled", () => {
     expect(getByText(children).getAttribute("disabled")).toBeNull();
   });
 
+  test("adds `aria-disabled` when disabled", () => {
+    const children = "duckduck";
+
+    const { getByText } = render(
+      <ClickableBox disabled>{children}</ClickableBox>
+    );
+
+    expect(getByText(children).getAttribute("aria-disabled")).toBe("true");
+  });
+
   test("does not run passed in `onKeyPress`", () => {
     const onKeyPress = jest.fn();
 


### PR DESCRIPTION
This is needed because `disabled` is not a valid element on a `span` or `div`.

Relates to #11.

***

cc: @scottaohara, @giuseppeg