### PR TITLE
Set `tabIndex` to `-1` when disabled

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -41,6 +41,7 @@ class ClickableBox extends React.Component {
       innerRef,
       onClick,
       disabled,
+      tabIndex,
       // Prevent `onKeyPress` from being spread since we will call it in
       // `this.onKeyPress` and we don't want the user function to overwrite our
       // behavior.
@@ -52,7 +53,7 @@ class ClickableBox extends React.Component {
 
     return (
       <Component
-        tabIndex={isActiveButton ? 0 : undefined}
+        tabIndex={isActiveButton ? tabIndex : -1}
         role={isActiveButton ? "button" : undefined}
         onKeyPress={isActiveButton ? this.onKeyPress : undefined}
         onClick={isActiveButton ? onClick : undefined}
@@ -67,6 +68,7 @@ ClickableBox.propTypes = {
   onClick: PropTypes.func,
   is: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   style: PropTypes.shape({}),
+  tabIndex: PropTypes.number,
   disabled: PropTypes.bool,
   onKeyPress: PropTypes.func,
   innerRef: PropTypes.oneOfType([
@@ -80,6 +82,7 @@ ClickableBox.defaultProps = {
   onClick: undefined,
   is: "span",
   style: undefined,
+  tabIndex: 0,
   disabled: false,
   onKeyPress: undefined,
   innerRef: undefined

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -57,18 +57,16 @@ test("allows `ref` prop", () => {
   expect(ref.current).toBeTruthy();
 });
 
-describe("merges props", () => {
-  test("allows overwriting of `tabIndex`", () => {
-    const children = "duckduck";
+test("allows overwriting of `tabIndex`", () => {
+  const children = "duckduck";
 
-    const { getByText } = render(
-      <ClickableBox tabIndex={-100} onClick={() => {}}>
-        {children}
-      </ClickableBox>
-    );
+  const { getByText } = render(
+    <ClickableBox tabIndex={-100} onClick={() => {}}>
+      {children}
+    </ClickableBox>
+  );
 
-    expect(getByText(children).getAttribute("tabIndex")).toBe("-100");
-  });
+  expect(getByText(children).getAttribute("tabIndex")).toBe("-100");
 });
 
 describe("events", () => {
@@ -184,14 +182,27 @@ describe("events", () => {
 });
 
 describe("disabled", () => {
-  test("does not add `tabIndex`", () => {
+  test("sets `tabIndex` to `-1`", () => {
     const children = "duckduck";
 
     const { getByText } = render(
       <ClickableBox disabled>{children}</ClickableBox>
     );
 
-    expect(getByText(children).getAttribute("tabIndex")).toBe(null);
+    expect(getByText(children).getAttribute("tabIndex")).toBe("-1");
+  });
+
+  test("does not allow custom `tabIndex`", () => {
+    const children = "duckduck";
+
+    const { getByText } = render(
+      // eslint-disable-next-line jsx-a11y/tabindex-no-positive
+      <ClickableBox disabled tabIndex={123}>
+        {children}
+      </ClickableBox>
+    );
+
+    expect(getByText(children).getAttribute("tabIndex")).toBe("-1");
   });
 
   test("does not fire event when space is pressed", () => {
@@ -251,12 +262,12 @@ describe("disabled", () => {
 });
 
 describe("`onClick` prop is not provided", () => {
-  test("does not add `tabIndex`", () => {
+  test("sets `tabIndex` to `-1`", () => {
     const children = "duckduck";
 
     const { getByText } = render(<ClickableBox>{children}</ClickableBox>);
 
-    expect(getByText(children).getAttribute("tabIndex")).toBe(null);
+    expect(getByText(children).getAttribute("tabIndex")).toBe("-1");
   });
 
   test("does not error when space is pressed", () => {


### PR DESCRIPTION
This sets the `tabIndex` to `-1` when disabled and also prevers users from passing in their own `tabIndex` if `disabled`.

Relates to #11.

***
cc: @scottaohara, @giuseppeg