### PR TITLE
Prevent scrolling when pressing Spacebar

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,6 +13,10 @@ class ClickableBox extends React.Component {
 
     switch (event.key) {
       case " ":
+      case "Spacebar": // Old browsers.
+        // Prevent scrolling when pressing Spacebar.
+        event.preventDefault();
+
         // If space is pressed and both `onKeyPress` and `onClick` exist, only
         // run `onKeyPress`.
         if (onClick && onKeyPress) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,8 +13,8 @@ class ClickableBox extends React.Component {
 
     switch (event.key) {
       case " ":
-      case "Spacebar": // Old browsers.
-        // Prevent scrolling when pressing Spacebar.
+      case "Spacebar": // Support FF <= 37, IE 9-11.
+        // Prevent scrolling when pressing `Spacebar`.
         event.preventDefault();
 
         // If space is pressed and both `onKeyPress` and `onClick` exist, only


### PR DESCRIPTION
Fixes #23

I couldn't think of a way to test this as Jest (JSDom) won't scroll elements on keypress and the following wouldn't work:

```js
const { getByTestId } = render(
  <div style={{ height: 300, overflow: 'scroll' }} data-testid="container">
    <div style={{ height: 500 }}>
      <ClickableBox>Submit</ClickableBox>
    </div>
  </div>
);

const container = getByTestId("container")
expect(container.scrollTop).toBe(0)
fireEvent.keyPress(getByText("Submit"), { charCode: charCode.enter });
expect(container.scrollTop).toBe(0)
```