### PR TITLE
Add comment explaining the use of `displayName`.

### DIFF
--- a/.changeset/stupid-mirrors-hide.md
+++ b/.changeset/stupid-mirrors-hide.md
@@ -1,0 +1,5 @@
+---
+"clickable-box": patch
+---
+
+Add comment explaining the use of `displayName`.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,6 +92,7 @@ const ClickableBox = React.forwardRef<HTMLElement, ClickableBoxProps>(
   }
 );
 
+// This is needed because of the `forwardRef`.
 ClickableBox.displayName = "ClickableBox";
 
 export default ClickableBox;


### PR DESCRIPTION
It's helpful to set a `displayName` when using `forwardRef`:
https://reactjs.org/docs/forwarding-refs.html#displaying-a-custom-name-in-devtools